### PR TITLE
feat: add RunOrReuse helper method for network reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,12 @@ network, err := ethereum.Run(ctx,
     ethereum.Minimal(),
     ethereum.WithReuse("my-persistent-network"),
 )
+
+// Or use the RunOrReuse helper method (recommended)
+network, err := ethereum.RunOrReuse(ctx, "my-persistent-network", ethereum.Minimal())
 ```
+
+The `RunOrReuse` function looks for an existing network with the given name and reuses it if found. If no network exists with that name, it creates a new one with the specified configuration.
 
 ### Explicit Cleanup
 For manual control over cleanup timing:

--- a/ethereum.go
+++ b/ethereum.go
@@ -281,6 +281,13 @@ func FindOrCreateNetwork(ctx context.Context, enclaveName string, opts ...RunOpt
 	return Run(ctx, allOpts...)
 }
 
+// RunOrReuse is a convenience function that looks for existing networks with the given name
+// and reuses that network if it exists. If it doesn't exist, it runs a new network like normal.
+// This is equivalent to FindOrCreateNetwork but with a more intuitive name.
+func RunOrReuse(ctx context.Context, networkName string, opts ...RunOption) (network.Network, error) {
+	return FindOrCreateNetwork(ctx, networkName, opts...)
+}
+
 // validateRunConfig validates the run configuration
 func validateRunConfig(cfg *RunConfig) error {
 	if cfg.PackageID == "" {


### PR DESCRIPTION
## Summary
Add `RunOrReuse` convenience function that looks for existing networks by name and reuses them if found, otherwise creates new networks. This provides a more intuitive API for users who want to reuse existing networks.

## Changes
- Add `RunOrReuse` function that wraps the existing `FindOrCreateNetwork` functionality
- Update README with usage examples and documentation
- Maintains backward compatibility with existing `FindOrCreateNetwork`

## Test plan
- [x] Function compiles successfully
- [x] Maintains existing functionality through `FindOrCreateNetwork`
- [ ] Manual testing with existing and new network names
- [ ] Integration tests pass