### PR TITLE
feat(client): add ethrex and nimbus-eth1 execution client types

### DIFF
--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -10,6 +10,12 @@ const (
 	Nethermind Type = "nethermind"
 	Erigon     Type = "erigon"
 	Reth       Type = "reth"
+	Ethrex     Type = "ethrex"
+	// NimbusEth1 is the nimbus-eth1 execution client. The upstream
+	// ethereum-package Kurtosis module accepts this as "nimbus", which
+	// collides with the consensus-client name. We expose the disambiguated
+	// "nimbusel" alias here and translate on marshal (see MarshalYAML).
+	NimbusEth1 Type = "nimbusel"
 
 	// Consensus clients
 	Lighthouse Type = "lighthouse"
@@ -23,14 +29,30 @@ const (
 	Unknown Type = "unknown"
 )
 
+// upstreamELName is the wire name the upstream ethereum-package Kurtosis
+// module expects for execution clients whose exported constant differs.
+var upstreamELName = map[Type]string{
+	NimbusEth1: "nimbus",
+}
+
 // IsExecution returns true if the client type is an execution client
 func (t Type) IsExecution() bool {
 	switch t {
-	case Geth, Besu, Nethermind, Erigon, Reth:
+	case Geth, Besu, Nethermind, Erigon, Reth, Ethrex, NimbusEth1:
 		return true
 	default:
 		return false
 	}
+}
+
+// MarshalYAML translates disambiguated aliases (e.g. NimbusEth1 → "nimbus")
+// to the string the upstream ethereum-package Kurtosis module expects. All
+// other values round-trip as their raw string.
+func (t Type) MarshalYAML() (interface{}, error) {
+	if name, ok := upstreamELName[t]; ok {
+		return name, nil
+	}
+	return string(t), nil
 }
 
 // IsConsensus returns true if the client type is a consensus client

--- a/pkg/client/types_test.go
+++ b/pkg/client/types_test.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestTypeIsExecution(t *testing.T) {
+	tests := []struct {
+		clientType  Type
+		isExecution bool
+	}{
+		{Geth, true},
+		{Besu, true},
+		{Nethermind, true},
+		{Erigon, true},
+		{Reth, true},
+		{Ethrex, true},
+		{NimbusEth1, true},
+		{Lighthouse, false},
+		{Teku, false},
+		{Prysm, false},
+		{Nimbus, false},
+		{Lodestar, false},
+		{Grandine, false},
+		{Unknown, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.clientType), func(t *testing.T) {
+			assert.Equal(t, tt.isExecution, tt.clientType.IsExecution())
+		})
+	}
+}
+
+func TestTypeMarshalYAML(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  Type
+		expect string
+	}{
+		{"geth is passthrough", Geth, "geth\n"},
+		{"ethrex is passthrough", Ethrex, "ethrex\n"},
+		{"nimbusel translates to upstream nimbus wire name", NimbusEth1, "nimbus\n"},
+		{"consensus nimbus is passthrough", Nimbus, "nimbus\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, string(data))
+		})
+	}
+}

--- a/pkg/config/yaml_test.go
+++ b/pkg/config/yaml_test.go
@@ -53,6 +53,25 @@ func TestToYAML(t *testing.T) {
 	assert.Contains(t, yamlStr, "global_log_level: info")
 }
 
+// TestToYAMLNimbusEth1WireName verifies that the user-facing NimbusEth1
+// ("nimbusel") alias is translated to the "nimbus" wire name that upstream
+// ethereum-package expects for the nimbus-eth1 execution client.
+func TestToYAMLNimbusEth1WireName(t *testing.T) {
+	config := &EthereumPackageConfig{
+		Participants: []ParticipantConfig{
+			{ELType: client.NimbusEth1, CLType: client.Teku},
+			{ELType: client.Ethrex, CLType: client.Lighthouse},
+		},
+	}
+
+	yamlStr, err := ToYAML(config)
+	require.NoError(t, err)
+
+	assert.Contains(t, yamlStr, "el_type: nimbus", "NimbusEth1 must serialize as upstream wire name 'nimbus'")
+	assert.NotContains(t, yamlStr, "el_type: nimbusel", "'nimbusel' alias must not leak to upstream YAML")
+	assert.Contains(t, yamlStr, "el_type: ethrex")
+}
+
 func TestToYAMLMinimal(t *testing.T) {
 	config := &EthereumPackageConfig{
 		Participants: []ParticipantConfig{

--- a/pkg/kurtosis/types.go
+++ b/pkg/kurtosis/types.go
@@ -118,6 +118,10 @@ func DetectClientType(serviceName string) client.Type {
 			return client.Erigon
 		case contains(serviceName, "reth"):
 			return client.Reth
+		case contains(serviceName, "ethrex"):
+			return client.Ethrex
+		case contains(serviceName, "nimbus-eth1"), contains(serviceName, "nimbusel"):
+			return client.NimbusEth1
 		}
 	}
 
@@ -133,6 +137,10 @@ func DetectClientType(serviceName string) client.Type {
 		return client.Erigon
 	case contains(serviceName, "reth"):
 		return client.Reth
+	case contains(serviceName, "ethrex"):
+		return client.Ethrex
+	case contains(serviceName, "nimbus-eth1"), contains(serviceName, "nimbusel"):
+		return client.NimbusEth1
 	case contains(serviceName, "lighthouse"):
 		return client.Lighthouse
 	case contains(serviceName, "teku"):

--- a/pkg/kurtosis/types_test.go
+++ b/pkg/kurtosis/types_test.go
@@ -65,6 +65,9 @@ func TestDetectClientType(t *testing.T) {
 		{"detect nethermind", "nethermind-node-1", client.Nethermind},
 		{"detect erigon", "erigon-archive", client.Erigon},
 		{"detect reth", "reth-full-node", client.Reth},
+		{"detect ethrex", "el-3-ethrex-lighthouse", client.Ethrex},
+		{"detect nimbus-eth1 (el)", "el-4-nimbus-eth1-teku", client.NimbusEth1},
+		{"detect nimbusel alias", "el-5-nimbusel-prysm", client.NimbusEth1},
 
 		// Consensus clients
 		{"detect lighthouse", "cl-1-lighthouse-geth", client.Lighthouse},

--- a/pkg/types/execution.go
+++ b/pkg/types/execution.go
@@ -10,6 +10,8 @@ const (
 	ClientNethermind ClientType = "nethermind"
 	ClientErigon     ClientType = "erigon"
 	ClientReth       ClientType = "reth"
+	ClientEthrex     ClientType = "ethrex"
+	ClientNimbusEth1 ClientType = "nimbusel"
 
 	// Unknown client
 	ClientUnknown ClientType = "unknown"


### PR DESCRIPTION
## Summary
Config validation currently rejects `ethrex` and `nimbus-eth1` with `invalid execution client type: <name>` because the `client.Type` enum hardcodes only `geth/besu/nethermind/erigon/reth`. Upstream `ethereum-package` supports both, so downstream callers (syncoor, bal-devnets) can't spin up those EL clients through this library today.

## What changes

- Add `client.Ethrex = \"ethrex\"` and `client.NimbusEth1 = \"nimbusel\"` to the `client.Type` enum.
- Extend `Type.IsExecution()` to accept both.
- Implement `Type.MarshalYAML()` that translates `NimbusEth1` (user-facing alias `\"nimbusel\"`) to the `\"nimbus\"` wire name the upstream ethereum-package Kurtosis module expects. All other types pass through unchanged. This keeps the Go API unambiguous while producing the correct upstream YAML (the upstream `EL_TYPE.nimbus` value collides with the consensus-client name, so an alias is necessary).
- Extend `kurtosis.DetectClientType()` to resolve service names containing `ethrex`, `nimbus-eth1`, or `nimbusel`. `nimbus-eth2` still resolves to the consensus client — the EL-specific cases are ordered before the generic `nimbus` match.
- Add mirror constants in `pkg/types/execution.go` (`ClientEthrex`, `ClientNimbusEth1`) for consumers iterating running execution clients.

## Why expose `NimbusEth1` as `\"nimbusel\"`

Upstream `ethereum-package` (`constants.star`) defines both:
- `EL_TYPE.nimbus = \"nimbus\"` (nimbus-eth1)
- `CL_TYPE.nimbus = \"nimbus\"` (nimbus-eth2)

A single string can only be one Go constant. Exposing the EL as `\"nimbusel\"` is the convention syncoor and the ethpandaops devnet workflows already use; `MarshalYAML` converts to `\"nimbus\"` on the wire so upstream is happy.

## Tests

- `pkg/client/types_test.go` (new): `IsExecution` covers Ethrex + NimbusEth1 (true) and every CL type (false); `MarshalYAML` asserts the `nimbusel → nimbus` translation and passthrough for all other values.
- `pkg/config/yaml_test.go`: new `TestToYAMLNimbusEth1WireName` — round-trip a participant with `ELType: client.NimbusEth1` and assert the serialized YAML contains `el_type: nimbus` (not `nimbusel`).
- `pkg/kurtosis/types_test.go`: new `DetectClientType` cases for `ethrex`, `nimbus-eth1`, and the `nimbusel` alias.

All existing tests still pass (`go test ./...`, `go vet`, `gofmt -l`). The existing `test.yml` workflow runs with `-race` so the new tests are covered automatically — no new CI jobs added.

## Follow-up
Syncoor bump PR will pick up this change so bal-devnets/blob-devnets et al. can run `ethrex` and `nimbusel` matrices without hitting the validation error.